### PR TITLE
Linking the contents of custom instead of the full directory

### DIFF
--- a/lib/oh_my_zsh.rb
+++ b/lib/oh_my_zsh.rb
@@ -39,11 +39,11 @@ private
         Dir["#{source_location}/*"]
     end
 
-    def remove_custom
-        system %Q{rm -rf "#{custom_location}"}
+    def new_path(path)
+        File.join(custom_location, File.basename(path))
     end
 
     def link_custom_contents
-        system %Q{ln -sv #{source_location} #{custom_location}}
+        custom_contents.each { |source| File.symlink(source, new_path(source)) }
     end
 end


### PR DESCRIPTION
This allows auto-updating because oh-my-zsh will not complain that the example files in custom are removed
